### PR TITLE
Add fallback_to_default arg to message_builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.6] - April 24, 2024
+
+- Add keyword argument `fallback_to_default` to `build_messages` function to allow for defaulting to the CL100k token encoder and minimum GPT token limit if the model is not found.
+- Fixed usage of `past_messages` argument of `build_messages` to not skip the last past message. (New user message should *not* be passed in)
+
 ## [0.0.5] - April 24, 2024
 
 - Add keyword argument `default_to_cl100k` to `count_tokens_for_message` function to allow for defaulting to the CL100k token limit if the model is not found.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Arguments:
 * `past_messages` (`list[dict]`): The list of past messages in the conversation.
 * `few_shots` (`list[dict]`): A few-shot list of messages to insert after the system prompt.
 * `max_tokens` (`int`): The maximum number of tokens allowed for the conversation.
+* `fallback_to_default` (`bool`): Whether to fallback to default model/token limits if model is not found. Defaults to `False`.
 
 Returns:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openai-messages-token-helper"
 description = "A helper library for estimating tokens used by messages sent through OpenAI Chat Completions API."
-version = "0.0.5"
+version = "0.0.6"
 authors = [{name = "Pamela Fox"}]
 requires-python = ">=3.9"
 readme = "README.md"

--- a/tests/test_messagebuilder.py
+++ b/tests/test_messagebuilder.py
@@ -1,3 +1,4 @@
+import pytest
 from openai_messages_token_helper import build_messages, count_tokens_for_message
 
 from .messages import system_message_short, system_message_unicode, user_message, user_message_unicode
@@ -33,3 +34,24 @@ def test_messagebuilder_unicode_append():
     assert messages == [system_message_unicode["message"], user_message_unicode["message"]]
     assert count_tokens_for_message("gpt-35-turbo", messages[0]) == system_message_unicode["count"]
     assert count_tokens_for_message("gpt-35-turbo", messages[1]) == user_message_unicode["count"]
+
+
+def test_messagebuilder_model_error():
+    model = "phi-3"
+    with pytest.raises(ValueError, match="Called with unknown model name: phi-3"):
+        build_messages(
+            model, system_message_short["message"]["content"], new_user_message=user_message["message"]["content"]
+        )
+
+
+def test_messagebuilder_model_fallback():
+    model = "phi-3"
+    messages = build_messages(
+        model,
+        system_message_short["message"]["content"],
+        new_user_message=user_message["message"]["content"],
+        fallback_to_default=True,
+    )
+    assert messages == [system_message_short["message"], user_message["message"]]
+    assert count_tokens_for_message(model, messages[0], default_to_cl100k=True) == system_message_short["count"]
+    assert count_tokens_for_message(model, messages[1], default_to_cl100k=True) == user_message["count"]


### PR DESCRIPTION
This pull request primarily focuses on the addition of a new feature to the `openai-messages-token-helper` library, which allows for falling back to default model/token limits if a specific model is not found. The version of the library has been updated to reflect this new feature. Additionally, some refactoring has been done to simplify the codebase, and tests have been added to validate the new functionality.

Here are the most important changes:

New Feature:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R9): A new version (0.0.6) has been added to the changelog, detailing the addition of the `fallback_to_default` argument to the `build_messages` function and a fix to the usage of `past_messages` argument.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38): The `fallback_to_default` argument has been added to the documentation in the `Arguments:` section.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4): The version of the library has been updated to 0.0.6.
* [`src/openai_messages_token_helper/message_builder.py`](diffhunk://#diff-3a5842046ec5c9d2af5f6a3e44dde4212a830669262f2720559a49c80fd2067aR71): The `fallback_to_default` argument has been added to the `build_messages` function, and its usage has been implemented in the function. [[1]](diffhunk://#diff-3a5842046ec5c9d2af5f6a3e44dde4212a830669262f2720559a49c80fd2067aR71) [[2]](diffhunk://#diff-3a5842046ec5c9d2af5f6a3e44dde4212a830669262f2720559a49c80fd2067aR84-R88) [[3]](diffhunk://#diff-3a5842046ec5c9d2af5f6a3e44dde4212a830669262f2720559a49c80fd2067aL102-R104)

Refactoring:

* [`src/openai_messages_token_helper/message_builder.py`](diffhunk://#diff-3a5842046ec5c9d2af5f6a3e44dde4212a830669262f2720559a49c80fd2067aL3): The `collections.abc` import has been removed as it was no longer needed. The `count_tokens_for_message` method of the `MessageBuilder` class has been removed and its usage has been replaced with direct calls to the `count_tokens_for_message` function. [[1]](diffhunk://#diff-3a5842046ec5c9d2af5f6a3e44dde4212a830669262f2720559a49c80fd2067aL3) [[2]](diffhunk://#diff-3a5842046ec5c9d2af5f6a3e44dde4212a830669262f2720559a49c80fd2067aL55-L57)

Testing:

* [`tests/test_messagebuilder.py`](diffhunk://#diff-8e55fc8483b1c062a6cb1009da723bdcc738ceeb3c0e76d967c100175027ddafR1): Two new tests have been added to validate the behavior of the `fallback_to_default` argument. One test checks for a `ValueError` when an unknown model name is used without fallback, and the other test checks that the fallback works correctly. [[1]](diffhunk://#diff-8e55fc8483b1c062a6cb1009da723bdcc738ceeb3c0e76d967c100175027ddafR1) [[2]](diffhunk://#diff-8e55fc8483b1c062a6cb1009da723bdcc738ceeb3c0e76d967c100175027ddafR37-R57)