### PR TITLE
Add OpenAI model names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.10] - Aug 7, 2024
+
+- Add additional OpenAI.com model names to the `get_token_limit` function.
+
 ## [0.1.9] - Aug 7, 2024
 
 - Add gpt-4o-mini support, by adding a 33.3x multiplier to the token cost.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openai-messages-token-helper"
 description = "A helper library for estimating tokens used by messages sent through OpenAI Chat Completions API."
-version = "0.1.9"
+version = "0.1.10"
 authors = [{name = "Pamela Fox"}]
 requires-python = ">=3.9"
 readme = "README.md"

--- a/src/openai_messages_token_helper/model_helper.py
+++ b/src/openai_messages_token_helper/model_helper.py
@@ -23,6 +23,14 @@ MODELS_2_TOKEN_LIMITS = {
     "gpt-4v": 128000,
     "gpt-4o": 128000,
     "gpt-4o-mini": 128000,
+    # OpenAI specific model names:
+    # https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4
+    "gpt-4-0613": 8192,
+    "gpt-4-turbo": 128000,
+    "gpt-4-turbo-2024-04-09": 128000,
+    "gpt-4-turbo-preview": 128000,
+    "gpt-4-0125-preview": 128000,
+    "gpt-4-1106-preview": 128000,
 }
 
 


### PR DESCRIPTION
Fixes #18 by adding OpenAI.com-specific model names. Azure OpenAI tends to use version identifiers in the deployment, while OpenAI sticks the versions into the name itself.