### PR TITLE
Add GPT-5.x models with reasoning model warnings

### DIFF
--- a/src/openai_messages_token_helper/model_helper.py
+++ b/src/openai_messages_token_helper/model_helper.py
@@ -40,13 +40,17 @@ MODELS_2_TOKEN_LIMITS = {
     "gpt-5-mini": 272000,
     "gpt-5-nano": 272000,
     "gpt-5-chat": 128000,
+    "gpt-5.1": 272000,
+    "gpt-5.1-chat": 111616,
+    "gpt-5.2": 272000,
+    "gpt-5.2-chat": 111616,
 }
 
 
 AOAI_2_OAI = {"gpt-35-turbo": "gpt-3.5-turbo", "gpt-35-turbo-16k": "gpt-3.5-turbo-16k", "gpt-4v": "gpt-4-turbo-vision"}
 
 # Set of reasoning models that cannot have token usage pre-estimated
-REASONING_MODELS = {"gpt-5", "gpt-5-mini", "gpt-5-nano"}
+REASONING_MODELS = {"gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5.1", "gpt-5.1-chat", "gpt-5.2"}
 
 logger = logging.getLogger("openai_messages_token_helper")
 

--- a/tests/test_modelhelper.py
+++ b/tests/test_modelhelper.py
@@ -20,6 +20,10 @@ def test_get_token_limit():
     assert get_token_limit("gpt-5-mini") == 272000
     assert get_token_limit("gpt-5-nano") == 272000
     assert get_token_limit("gpt-5-chat") == 128000
+    assert get_token_limit("gpt-5.1") == 272000
+    assert get_token_limit("gpt-5.1-chat") == 111616
+    assert get_token_limit("gpt-5.2") == 272000
+    assert get_token_limit("gpt-5.2-chat") == 111616
 
 
 def test_get_token_limit_error():


### PR DESCRIPTION
This PR adds support for the new GPT-5.x model family and implements warning functionality for reasoning models that cannot have token usage pre-estimated.

https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
# New Models Added
- <b>gpt-5.1:</b> 272,000 tokens (reasoning model)
- <b>gpt-5.1-chat:</b> 111,616 tokens (reasoning model)
- <b>gpt-5.2:</b> 272,000 tokens (reasoning model)
- <b>gpt-5.2-chat:</b> 111,616 tokens (standard model)

## Motivation and Context
Added support for new GPT-5.x model family

## How Has This Been Tested?
Tested locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

